### PR TITLE
Fix segfaults in GLib applications when the PAM module is unloaded or reloaded.

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -287,5 +287,5 @@ gboolean CacheEntryPasswordValidate(CacheEntry *self, const gchar *password,
 
 GQuark
 _CacheEntryErrorQuark() {
-  return g_quark_from_static_string("cache-entry-error-quark");
+  return g_quark_from_string("cache-entry-error-quark");
 }

--- a/src/module.c
+++ b/src/module.c
@@ -276,5 +276,5 @@ pam_sm_chauthtok(
 
 GQuark
 _CacheModuleErrorQuark() {
-  return g_quark_from_static_string("cache-module-error-quark");
+  return g_quark_from_string("cache-module-error-quark");
 }

--- a/src/policy.c
+++ b/src/policy.c
@@ -359,5 +359,5 @@ gboolean CachePolicyShouldRenew(CachePolicy *self, CacheEntry *entry,
 
 GQuark
 _CachePolicyErrorQuark() {
-  return g_quark_from_static_string("cache-policy-error-quark");
+  return g_quark_from_string("cache-policy-error-quark");
 }

--- a/src/storage.c
+++ b/src/storage.c
@@ -160,5 +160,5 @@ done:
 
 GQuark
 _CacheStorageErrorQuark() {
-  return g_quark_from_static_string("cache-storage-error-quark");
+  return g_quark_from_string("cache-storage-error-quark");
 }


### PR DESCRIPTION
We need to use copies of strings instead of static string for creating GQuarks that are used for error handling. If this library is unloaded but GLib isn't, static strings won't be available afterwards so they can cause a segfault.

https://developer.gnome.org/glib/stable/glib-Quarks.html#g-quark-from-static-string
