### PR TITLE
Fix Kerberos credential refreshes under pam_escalate.so and apps like gnome-screensaver.

### DIFF
--- a/src/escalate_helper.c
+++ b/src/escalate_helper.c
@@ -260,7 +260,7 @@ gboolean EscalateHelperDoAction(EscalateHelper *self, GError **error) {
         // even if the client never calls pam_setcred() because the entire auth
         // stack succeeded.
         // TODO(vonhollen): Make this configurable by pam_escalate.so.
-        setcred_result = pam_setcred(self->pamh, PAM_REFRESH_CRED);
+        setcred_result = pam_setcred(self->pamh, PAM_REINITIALIZE_CRED);
         if (setcred_result != PAM_SUCCESS) {
           pam_syslog(self->pamh, LOG_NOTICE,
                      "pam_setcred() failed for user '%s': %s",

--- a/src/escalate_test.c
+++ b/src/escalate_test.c
@@ -241,7 +241,7 @@ int __wrap_pam_authenticate(MockPamHandle *self, int flags) {
 
 int __wrap_pam_setcred(MockPamHandle *self, int flags) {
   g_assert(self);
-  g_assert(flags == PAM_REFRESH_CRED);
+  g_assert(flags == PAM_REINITIALIZE_CRED);
   return PAM_SUCCESS;
 }
 

--- a/src/pam_test_tool.c
+++ b/src/pam_test_tool.c
@@ -191,14 +191,18 @@ int main(int argc, char **argv) {
   if (do_auth) {
     g_print("pam_authenticate(pamh, 0)\n");
     pam_result = pam_authenticate(pamh, 0);
-    if (pam_result) {
-      goto pam_done;
+    switch (pam_result) {
+      case PAM_SUCCESS:
+      case PAM_NEW_AUTHTOK_REQD:
+        break;
+      default:
+        goto pam_done;
     }
     PrintPamInfo(pamh);
 
     g_print("pam_setcred(pamh, %d)\n", setcred_style);
     pam_result = pam_setcred(pamh, setcred_style);
-    if (pam_result) {
+    if (pam_result != PAM_SUCCESS) {
       goto pam_done;
     }
     PrintPamInfo(pamh);


### PR DESCRIPTION
Applications like gnome-screensaver don't set a PAM environment at all. It's usually OK because modules like pam_krb5.so fall back to getenv() when pam_getenv() returns nothing. Since pam_escalate.so wipes all environment variables when it starts (it's setuid-root so it's paranoid), the fallback to getenv() doesn't work.

With this change, a line like "auth ... pam_escalate.so add_env=KRB5CCNAME" would add KRB5CCNAME (Kerberos credential cache path) to the PAM environment sent to pam-escalate-helper if it wasn't already set.

I'd like a better way to do this, like another module similar to pam_env, but this action is probably only useful to pam_escalate.so because of the helper's unique behavior.
